### PR TITLE
Allow flags to be specified for postgres user

### DIFF
--- a/apps/postgres-initdb/entrypoint.sh
+++ b/apps/postgres-initdb/entrypoint.sh
@@ -28,7 +28,7 @@ user_exists=$(\
 
 if [[ -z "${user_exists}" ]]; then
     printf "\e[1;32m%-6s\e[m\n" "Create User ${POSTGRES_USER} ..."
-    createuser "${POSTGRES_USER}"
+    createuser ${POSTGRES_USER_FLAGS} "${POSTGRES_USER}"
     printf "\e[1;32m%-6s\e[m\n" "Update User Password ..."
     psql --command "alter user \"${POSTGRES_USER}\" with encrypted password '${POSTGRES_PASS}';"
 fi


### PR DESCRIPTION
Some containers (e.g. teslamate) require additional privileges like super-user. This allows the create user flags to be specified.