### PR TITLE
Move base images to v2 of registry API for latest check

### DIFF
--- a/apps/alpine/ci/latest.sh
+++ b/apps/alpine/ci/latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 channel=$1
-version=$(curl -s "https://registry.hub.docker.com/v1/repositories/library/alpine/tags" | jq --raw-output --arg s "$channel" '.[] | select(.name | contains($s)) | .name'  | tail -n1)
+version=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/alpine/tags?ordering=name&name=$channel" | jq --raw-output --arg s "$channel" '.results[] | select(.name | contains($s)) | .name'  | head -n1)
 version="${version#*v}"
 version="${version#*release-}"
 printf "%s" "${version}"

--- a/apps/ubuntu/ci/latest.sh
+++ b/apps/ubuntu/ci/latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 channel=$1
-version=$(curl -s "https://registry.hub.docker.com/v1/repositories/library/ubuntu/tags" | jq --raw-output --arg s "$channel" '.[] | select(.name | contains($s)) | .name'  | tail -n1)
+version=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/ubuntu/tags?ordering=name&name=$channel" | jq --raw-output --arg s "$channel" '.results[] | select(.name | contains($s)) | .name'  | head -n1)
 version="${version#*v}"
 version="${version#*release-}"
 printf "%s" "${version}"


### PR DESCRIPTION
v1 of the registry API intermitently fails with a 410 gone error

This moves the latest scripts to use v2 of the API

I've updated them to use some search terms as well to limit the results