### PR TITLE
feat: migrate back to docker buildx

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -36,9 +36,6 @@ on:
         default: 'false'
         type: string
 
-env:
-  IMAGE_REGISTRY_GHCR: ghcr.io
-
 jobs:
   build-and-test:
     name: Build and test
@@ -92,18 +89,18 @@ jobs:
           fi
 
           if [[ "${chan_stable}" == true ]]; then
+              echo "chan_tag_testing=${{ matrix.image.app }}:testingz" >> $GITHUB_OUTPUT
               echo "chan_tag_rolling=${{ matrix.image.app }}:rolling" >> $GITHUB_OUTPUT
               echo "chan_tag_version=${{ matrix.image.app }}:${chan_upstream_version}" >> $GITHUB_OUTPUT
           else
+              echo "chan_tag_testing=${{ matrix.image.app }}-${{ matrix.image.channel }}:testingz" >> $GITHUB_OUTPUT
               echo "chan_tag_rolling=${{ matrix.image.app }}-${{ matrix.image.channel }}:rolling" >> $GITHUB_OUTPUT
               echo "chan_tag_version=${{ matrix.image.app }}-${{ matrix.image.channel }}:${chan_upstream_version}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Setup tools
+      - name: Setup Tools
         shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y buildah moreutils jo qemu-user-static
+        run: sudo apt-get install -y moreutils jo
 
       - name: Setup CUE
         uses: cue-lang/setup-cue@v1.0.0-alpha.2
@@ -120,79 +117,91 @@ jobs:
         run: |-
           cue vet --schema '#Spec' ./apps/${{ matrix.image.app }}/metadata.json ./metadata.rules.cue
 
-      - name: Build all platforms
-        id: build_image
-        uses: redhat-actions/buildah-build@v2.10
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:latest
+
+      - name: Setup GHCR
+        if: ${{ inputs.pushImages == 'true' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build container image for testing
+        uses: docker/build-push-action@v3
         with:
           build-args: |-
             VERSION=${{ steps.vars.outputs.chan_upstream_version }}
             CHANNEL=${{ matrix.image.channel }}
-          platforms: ${{ steps.vars.outputs.chan_platforms }}
           context: .
-          containerfiles: |
-            ${{ steps.vars.outputs.chan_dockerfile }}
-          layers: true
-          extra-args: |
-            --cache-from
-            ${{ env.IMAGE_REGISTRY_GHCR }}/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_rolling }}
+          platforms: linux/amd64 # load does not support muti-arch https://github.com/docker/buildx/issues/290
+          file: ${{ steps.vars.outputs.chan_dockerfile }}
+          load: true
           tags: |-
-            ${{ env.IMAGE_REGISTRY_GHCR }}/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_rolling }}
-            ${{ env.IMAGE_REGISTRY_GHCR }}/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_version }}
-          labels: |-
-            ${{ steps.vars.outputs.chan_label_type }}.created="${{ steps.vars.outputs.chan_build_date }}"
-            ${{ steps.vars.outputs.chan_label_type }}.title="${{ matrix.image.app }} (${{ matrix.image.channel }})"
-            ${{ steps.vars.outputs.chan_label_type }}.version="${{ steps.vars.outputs.chan_upstream_version }}"
-            ${{ steps.vars.outputs.chan_label_type }}.authors="Devin Buhl <devin@buhl.casa>"
-            ${{ steps.vars.outputs.chan_label_type }}.url="https://github.com/onedr0p/containers/apps/${{ matrix.image.app }}"
-            ${{ steps.vars.outputs.chan_label_type }}.build.url="https://github.com/onedr0p/containers/actions/runs/${{ github.run_id }}"
-            ${{ steps.vars.outputs.chan_label_type }}.documentation="https://github.com/onedr0p/containers/apps/${{ matrix.image.app }}/README.md"
-            ${{ steps.vars.outputs.chan_label_type }}.revision="${{ github.sha }}"
+            ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_testing }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run Goss tests
         id: dgoss
         if: ${{ steps.vars.outputs.chan_tests_enabled == 'true' }}
         shell: bash
         env:
-          CONTAINER_RUNTIME: podman
+          CONTAINER_RUNTIME: docker
           GOSS_FILE: ${{ steps.vars.outputs.chan_goss_config }}
           GOSS_OPTS: |-
-            --sleep 5s --retry-timeout 60s --color --format documentation
-          GOSS_SLEEP: 2
-          GOSS_FILES_STRATEGY: cp
-          CONTAINER_LOG_OUTPUT: goss_container_log_output
+            --retry-timeout 60s --sleep 2s --color --format documentation
         run: >
-          dgoss run ${{ env.IMAGE_REGISTRY_GHCR }}/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_rolling }} ${{ steps.vars.outputs.chan_goss_args }}
+          dgoss run ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_testing }} ${{ steps.vars.outputs.chan_goss_args }}
 
-      - name: Push To GHCR
-        id: push_to_ghcr
-        if: ${{ inputs.pushImages == 'true' }}
-        uses: redhat-actions/push-to-registry@v2.6
+      - name: Build all platforms
+        id: release
+        uses: docker/build-push-action@v3
         with:
-          image: ${{ steps.build_image.outputs.image }}
-          tags: ${{ steps.build_image.outputs.tags }}
-          registry: ${{ env.IMAGE_REGISTRY_GHCR }}/${{ env.IMAGE_NAMESPACE }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          build-args: |-
+            VERSION=${{ steps.vars.outputs.chan_upstream_version }}
+            CHANNEL=${{ matrix.image.channel }}
+          labels: |-
+            ${{ steps.vars.outputs.chan_label_type }}.created="${{ steps.vars.outputs.chan_build_date }}"
+            ${{ steps.vars.outputs.chan_label_type }}.title="${{ matrix.image.app }} (${{ matrix.image.channel }})"
+            ${{ steps.vars.outputs.chan_label_type }}.version="${{ steps.vars.outputs.chan_upstream_version }}"
+            ${{ steps.vars.outputs.chan_label_type }}.authors="Devin Buhl <devin.kray@gmail.com>, Bernd Schorgers <me@bjw-s.dev>"
+            ${{ steps.vars.outputs.chan_label_type }}.url="https://github.com/onedr0p/containers/apps/${{ matrix.image.app }}"
+            ${{ steps.vars.outputs.chan_label_type }}.build.url="https://github.com/onedr0p/containers/actions/runs/${{ github.run_id }}"
+            ${{ steps.vars.outputs.chan_label_type }}.documentation="https://github.com/onedr0p/containers/apps/${{ matrix.image.app }}/README.md"
+            ${{ steps.vars.outputs.chan_label_type }}.revision="${{ github.sha }}"
+          context: .
+          platforms: ${{ steps.vars.outputs.chan_platforms }}
+          file: ${{ steps.vars.outputs.chan_dockerfile }}
+          push: ${{ inputs.pushImages == 'true' }}
+          tags: |-
+            ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_rolling }}
+            ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build successful
         id: build-success
-        if: ${{ always() && steps.build_image.outcome == 'success' && steps.dgoss.outcome == 'success' && (steps.push_to_ghcr.outcome == 'success' || steps.push_to_ghcr.outcome == 'skipped') }}
+        if: ${{ always() && steps.release.outcome == 'success' }}
         run: |-
-          echo "message=🎉 ${{ matrix.image.app }}-${{ matrix.image.channel }} (${{ steps.vars.outputs.chan_upstream_version }})" >> $GITHUB_OUTPUT
-          echo "color=0x00FF00" >> $GITHUB_OUTPUT
-          echo "::group::Container log output"
-          cat "goss_container_log_output"
-          echo "::endgroup::"
+          echo "::set-output name=message::🎉 ${{ matrix.image.app }}-${{ matrix.image.channel }} (${{ steps.vars.outputs.chan_upstream_version }})"
+          echo "::set-output name=color::0x00FF00"
 
       - name: Build failed
         id: build-failed
-        if: ${{ always() && (steps.build_image.outcome == 'failure' || steps.dgoss.outcome == 'failure' || steps.push_to_ghcr.outcome == 'failure') }}
+        if: ${{ always() && (steps.release.outcome == 'failure' || steps.dgoss.outcome == 'failure') }}
         run: |-
-          echo "message=💥 ${{ matrix.image.app }}-${{ matrix.image.channel }} (${{ steps.vars.outputs.chan_upstream_version }})" >> $GITHUB_OUTPUT
-          echo "color=0xFF0000" >> $GITHUB_OUTPUT
-          echo "::group::Container log output"
-          cat "goss_container_log_output"
-          echo "::endgroup::"
+          echo "::set-output name=message::💥 ${{ matrix.image.app }}-${{ matrix.image.channel }} (${{ steps.vars.outputs.chan_upstream_version }})"
+          echo "::set-output name=color::0xFF0000"
 
       - name: Send Discord Webhook
         uses: sarisia/actions-status-discord@v1

--- a/apps/unpackerr/Dockerfile
+++ b/apps/unpackerr/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM --platform=$TARGETPLATFORM public.ecr.aws/docker/library/golang:1.19.2-alpine3.16 as builder
+FROM public.ecr.aws/docker/library/golang:1.19.2-alpine3.16 as builder
 ARG VERSION
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
This is due to issues in multi-arch builds which seem to be related to buildah being several version behind in the runners.

Signed-off-by: Devin Buhl <devin@buhl.casa>