### PR TITLE
fix: Add newlines to various printf format strings

### DIFF
--- a/apps/alpine/Dockerfile
+++ b/apps/alpine/Dockerfile
@@ -60,7 +60,7 @@ RUN \
     && chown -R kah:kah /config \
     && chmod -R 775 /config \
     && printf "/bin/bash /scripts/greeting.sh\n" > /etc/profile.d/greeting.sh \
-    && printf "umask %d" "${UMASK}" > /etc/profile.d/umask.sh \
+    && printf "umask %d\n" "${UMASK}" > /etc/profile.d/umask.sh \
     && ln -s /usr/bin/vi   /usr/local/bin/vi \
     && ln -s /usr/bin/vi   /usr/local/bin/vim \
     && ln -s /usr/bin/nano /usr/local/bin/nano \

--- a/apps/emby/Dockerfile
+++ b/apps/emby/Dockerfile
@@ -73,7 +73,7 @@ RUN \
         /var/tmp/ \
     && chown -R root:root /app \
     && chmod -R 755 /app \
-    && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc
+    && printf "umask %d\n" "${UMASK}" >> /etc/bash.bashrc
 
 USER kah
 COPY --from=builder /app/emby /app/emby

--- a/apps/jellyfin/Dockerfile
+++ b/apps/jellyfin/Dockerfile
@@ -54,7 +54,7 @@ RUN \
         /tmp/* \
         /var/lib/apt/lists/* \
         /var/tmp/ \
-    && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc
+    && printf "umask %d\n" "${UMASK}" >> /etc/bash.bashrc
 
 USER kah
 COPY ./apps/jellyfin/entrypoint.sh /entrypoint.sh

--- a/apps/lidarr/Dockerfile
+++ b/apps/lidarr/Dockerfile
@@ -26,7 +26,7 @@ RUN \
         /app/Lidarr.Update \
         /app/fpcalc \
     && \
-    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)" "${LIDARR__BRANCH}" "${VERSION}" > /app/package_info \
+    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)\n" "${LIDARR__BRANCH}" "${VERSION}" > /app/package_info \
     && chown -R root:root /app \
     && chmod -R 755 /app \
     && rm -rf /tmp/*

--- a/apps/plex/Dockerfile
+++ b/apps/plex/Dockerfile
@@ -46,7 +46,7 @@ RUN \
         /var/tmp/ \
     && chown -R root:root /app \
     && chmod -R 755 "${PLEX_MEDIA_SERVER_HOME}" \
-    && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc
+    && printf "umask %d\n" "${UMASK}" >> /etc/bash.bashrc
 
 WORKDIR "${PLEX_MEDIA_SERVER_HOME}"
 USER kah

--- a/apps/plex/amd/Dockerfile
+++ b/apps/plex/amd/Dockerfile
@@ -111,7 +111,7 @@ RUN \
         /var/tmp/ \
     && chown -R root:root /app \
     && chmod -R 755 "${PLEX_MEDIA_SERVER_HOME}" \
-    && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc
+    && printf "umask %d\n" "${UMASK}" >> /etc/bash.bashrc
 
 # Copy lib files
 COPY --from=amd /output/usr/lib/dri/*.so* /usr/lib/plexmediaserver/lib/dri/

--- a/apps/prowlarr/Dockerfile
+++ b/apps/prowlarr/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     rm -rf \
         /app/Prowlarr.Update \
     && \
-    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)" "${PROWLARR__BRANCH}" "${VERSION}" > /app/package_info \
+    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)\n" "${PROWLARR__BRANCH}" "${VERSION}" > /app/package_info \
     && chown -R root:root /app \
     && chmod -R 755 /app \
     && rm -rf /tmp/*

--- a/apps/radarr/Dockerfile
+++ b/apps/radarr/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     rm -rf \
         /app/Radarr.Update \
     && \
-    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)" "${RADARR__BRANCH}" "${VERSION}" > /app/package_info \
+    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)\n" "${RADARR__BRANCH}" "${VERSION}" > /app/package_info \
     && chown -R root:root /app \
     && chmod -R 755 /app \
     && rm -rf /tmp/*

--- a/apps/radarr/zeus/Dockerfile
+++ b/apps/radarr/zeus/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     rm -rf \
         /app/Radarr.Update \
     && \
-    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)" "${RADARR__BRANCH}" "${VERSION}" > /app/package_info \
+    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)\n" "${RADARR__BRANCH}" "${VERSION}" > /app/package_info \
     && chown -R root:root /app \
     && chmod -R 755 /app \
     && rm -rf /tmp/*

--- a/apps/readarr/Dockerfile
+++ b/apps/readarr/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     rm -rf \
         /app/Readarr.Update \
     && \
-    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)" "${READARR__BRANCH}" "${VERSION}" > /app/package_info \
+    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)\n" "${READARR__BRANCH}" "${VERSION}" > /app/package_info \
     && chown -R root:root /app \
     && chmod -R 755 /app \
     && rm -rf /tmp/*

--- a/apps/sabnzbd/entrypoint.sh
+++ b/apps/sabnzbd/entrypoint.sh
@@ -5,11 +5,11 @@ test -f "/scripts/umask.sh" && source "/scripts/umask.sh"
 test -f "/scripts/vpn.sh" && source "/scripts/vpn.sh"
 
 if [[ ! -f "/config/sabnzbd.ini" ]]; then
-    printf "Copying over default configuration ... "
+    printf "Copying over default configuration ...\n"
     mkdir -p /config/sabnzbd
     cp /app/sabnzbd.ini /config/sabnzbd.ini
 
-    printf "Creating api keys ..."
+    printf "Creating api keys ...\n"
     api_key=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
     nzb_key=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
     sed -i -e "s/^api_key *=.*$/api_key = ${api_key}/g" /config/sabnzbd.ini

--- a/apps/sonarr/Dockerfile
+++ b/apps/sonarr/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     curl -fsSL "https://download.sonarr.tv/v3/${SONARR__BRANCH}/${VERSION}/Sonarr.${SONARR__BRANCH}.${VERSION}.linux.tar.gz" \
         | tar xzf - -C /app --strip-components=1 \
     && \
-    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)" "${SONARR__BRANCH}" "${VERSION}" > /app/package_info \
+    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)\n" "${SONARR__BRANCH}" "${VERSION}" > /app/package_info \
     && \
     gpgconf --kill all \
     && apt-get remove -y gnupg \
@@ -44,7 +44,7 @@ RUN \
         /var/tmp/ \
     && chown -R root:root /app \
     && chmod -R 755 /app \
-    && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc
+    && printf "umask %d\n" "${UMASK}" >> /etc/bash.bashrc
 
 USER kah
 

--- a/apps/sonarr/develop/Dockerfile
+++ b/apps/sonarr/develop/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     rm -rf \
         /app/Sonarr.Update \
     && \
-    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)" "${SONARR__BRANCH}" "${VERSION}" > /app/package_info \
+    printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[onedr0p](https://github.com/onedr0p)\n" "${SONARR__BRANCH}" "${VERSION}" > /app/package_info \
     && chown -R root:root /app \
     && chmod -R 755 /app \
     && rm -rf /tmp/*


### PR DESCRIPTION
The Dockerfile RUN to add the umask to /etc/bash.bashrc was not including a newline so that subsequent appendings to the same file would cause an error.  Conducted an audit of the repository for various similar uses of printf and added newlines where it seemed to make sense.

Notable exceptions:
- apps/*/ci/latest.sh
- apps/*/scripts/sleep.sh

Signed-off-by: Dan Christensen <opello@opello.org>