### PR TITLE
Add concurrency to workflows to avoid multiple release builds

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -1,6 +1,10 @@
 ---
 name: "Manual Release"
 
+concurrency:
+  group: container-release
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-schedule.yaml
+++ b/.github/workflows/release-schedule.yaml
@@ -1,6 +1,10 @@
 ---
 name: "Scheduled Release"
 
+concurrency:
+  group: container-release
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/release-schedule.yaml
+++ b/.github/workflows/release-schedule.yaml
@@ -8,9 +8,7 @@ concurrency:
 on:
   workflow_dispatch:
   schedule:
-    # NOTE: The longest build for an app is ~1h30m
-    # Keep this to run every 2 or more hours to prevent gremlins from spawning
-    - cron: "0 */3 * * *"
+    - cron: "0 * * * *"
 
 env:
   TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
I propose to add concurrency to release builds.
It will allow to have action running every hour without spawning gremlins ;)
The next action will get into queue and will wait for previous execution to finish.

I use this successfully in my long running github actions.