### PR TITLE
Build containers for Prowlarr stable releases.

### DIFF
--- a/apps/prowlarr/metadata.json
+++ b/apps/prowlarr/metadata.json
@@ -3,6 +3,18 @@
   "base": false,
   "channels": [
     {
+      "name": "master",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    },
+    {
       "name": "develop",
       "platforms": [
         "linux/amd64",


### PR DESCRIPTION
Now that Prowlarr has stable releases, they should be built. 😄 