### PR TITLE
feat(postgres-init): ALTER ROLE every script run

### DIFF
--- a/apps/postgres-init/entrypoint.sh
+++ b/apps/postgres-init/entrypoint.sh
@@ -38,9 +38,10 @@ user_exists=$(\
 if [[ -z "${user_exists}" ]]; then
     printf "\e[1;32m%-6s\e[m\n" "Create User ${INIT_POSTGRES_USER} ..."
     createuser ${INIT_POSTGRES_USER_FLAGS} "${INIT_POSTGRES_USER}"
-    printf "\e[1;32m%-6s\e[m\n" "Update User Password ..."
-    psql --command "alter user \"${INIT_POSTGRES_USER}\" with encrypted password '${INIT_POSTGRES_PASS}';"
 fi
+
+printf "\e[1;32m%-6s\e[m\n" "Update User Password ..."
+psql --command "alter user \"${INIT_POSTGRES_USER}\" with encrypted password '${INIT_POSTGRES_PASS}';"
 
 for dbname in ${INIT_POSTGRES_DBNAME}; do
     database_exists=$(\

--- a/apps/postgres-init/entrypoint.sh
+++ b/apps/postgres-init/entrypoint.sh
@@ -40,7 +40,7 @@ if [[ -z "${user_exists}" ]]; then
     createuser ${INIT_POSTGRES_USER_FLAGS} "${INIT_POSTGRES_USER}"
 fi
 
-printf "\e[1;32m%-6s\e[m\n" "Update User Password ..."
+printf "\e[1;32m%-6s\e[m\n" "Update password for user ${INIT_POSTGRES_USER} ..."
 psql --command "alter user \"${INIT_POSTGRES_USER}\" with encrypted password '${INIT_POSTGRES_PASS}';"
 
 for dbname in ${INIT_POSTGRES_DBNAME}; do


### PR DESCRIPTION
This allows the intended app user's password to be rotated by the admin using the initContainer rather than manually using `psql`.