### PR TITLE
[feature] Leverage Matrices to build multi-arch images

### DIFF
--- a/.github/scripts/prepare-images.py
+++ b/.github/scripts/prepare-images.py
@@ -1,0 +1,92 @@
+#! /usr/bin/env python3
+
+import sys
+
+import json
+import subprocess
+
+from datetime import datetime, timezone
+from os.path import isfile
+
+
+def get_upstream_version(app, channel):
+    latest_script = f"./apps/{app}/ci/latest.sh"
+    if not isfile(latest_script):
+        return ""
+
+    args = [latest_script, channel]
+    output = subprocess.check_output(args)
+    return output.decode("utf-8").strip()
+
+if __name__ == "__main__":
+
+    changed_apps = json.loads(sys.argv[1])
+    forRelease = sys.argv[2] == "true"
+
+    out = {"manifestsToBuild": [], "imagePlatformPermutations": []}
+
+    for app in changed_apps:
+        name = app["app"]
+        channel = app["channel"]
+        with open(f"./apps/{name}/metadata.json") as f:
+            metadata = json.load(f)
+
+        # Generate Config
+        cfg = {}
+        for ch in metadata["channels"]:
+            if ch["name"] == channel:
+                cfg = ch
+                break
+
+        app["chan_build_date"] = datetime.now(timezone.utc).isoformat()
+        app["chan_stable"] = cfg["stable"]
+        app["chan_tests_enabled"] = cfg["tests"]["enabled"]
+        app["chan_tests_type"] = cfg["tests"]["type"]
+        app["chan_upstream_version"] = get_upstream_version(name, channel)
+
+        if app["chan_tests_enabled"] and app["chan_tests_type"] == "cli":
+            app["chan_goss_args"] = "tail -f /dev/null"
+
+        if app.get("base", False):
+            app["chan_label_type"] ="org.opencontainers.image.base"
+        else:
+            app["chan_label_type"]="org.opencontainers.image"
+
+        if isfile(f"./apps/{name}/{channel}/Dockerfile"):
+            app["chan_dockerfile"] = f"./apps/{name}/{channel}/Dockerfile"
+            app["chan_goss_config"] = f"./apps/{name}/{channel}/goss.yaml"
+        else:
+            app["chan_dockerfile"] = f"./apps/{name}/Dockerfile"
+            app["chan_goss_config"] = f"./apps/{name}/ci/goss.yaml"
+
+        if app["chan_stable"]:
+            app["chan_image_name"] = name
+            app["chan_tag_rolling"] = f"{name}:rolling"
+            app["chan_tag_version"] = f"{name}:{app['chan_upstream_version']}"
+            app["chan_tag_testing"] = f"{name}:testing"
+        else:
+            app["chan_image_name"] = f"{name}-{channel}"
+            app["chan_tag_rolling"] = f"{name}-{channel}:rolling"
+            app["chan_tag_version"] = f"{name}-{channel}:{app['chan_upstream_version']}"
+            app["chan_tag_testing"] = f"{name}-{channel}:testing"
+
+        for platform in cfg["platforms"]:
+            if platform != "linux/amd64" and not forRelease:
+                continue
+            to_append = app.copy()
+            to_append["platform"] = platform
+            if platform != "linux/amd64":
+                to_append["chan_tests_enabled"] = False
+            out["imagePlatformPermutations"].append(to_append)
+
+        manifest = {
+            "image": app["chan_image_name"],
+            "app": name,
+            "channel": channel,
+            "tags": [app["chan_tag_rolling"], app["chan_tag_version"]],
+            "version": app["chan_upstream_version"],
+        }
+        out["manifestsToBuild"].append(manifest)
+
+    print(json.dumps(out))
+

--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -26,77 +26,62 @@ on:
         default: 'false'
         type: string
 
-      updateMetadata:
-        required: false
-        default: 'false'
-        type: string
-
       sendNotification:
         required: false
         default: 'false'
         type: string
 
 jobs:
-  build-and-test:
-    name: Build and test
+  prepare:
+    name: Prepare Matrices
     runs-on: ubuntu-latest
-    if: inputs.imagesToBuild != '' && inputs.imagesToBuild != '[]'
-    strategy:
-      matrix:
-        image: ["${{ fromJson(inputs.imagesToBuild) }}"]
-      fail-fast: false
+    outputs:
+      matrices: ${{ steps.generate-matrices.outputs.matrices }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
-      - name: Setup workflow Variables
-        id: vars
-        shell: bash
-        run: |-
-          container_base=$(jq '.base' ./apps/${{ matrix.image.app }}/metadata.json)
-          echo "chan_build_date=$(date --rfc-3339=seconds --utc)" >> $GITHUB_OUTPUT
+      - name: Log images to build
+        run: |
+          echo 'imagesToBuild=${{ inputs.imagesToBuild }}'
+          echo 'pushImages=${{ inputs.pushImages }}'
+          echo 'sendNotification=${{ inputs.sendNotification }}'
 
-          chan_config=$(jq --arg chan "${{ matrix.image.channel }}" '(.channels | .[] | select(.name == $chan))' ./apps/${{ matrix.image.app }}/metadata.json)
-          chan_stable=$(jq --raw-output '.stable' <<< "${chan_config}")
+      - name: Generate Matrices
+        id: generate-matrices
+        run: |
+          matrices=$(./.github/scripts/prepare-images.py '${{ inputs.imagesToBuild }}' '${{ inputs.pushImages }}')
+          echo "matrices=${matrices}" >> $GITHUB_OUTPUT
 
-          chan_platforms=$(jq --raw-output '.platforms | join(",")' <<< "${chan_config}") && \
-              echo "chan_platforms=${chan_platforms}" >> $GITHUB_OUTPUT
-          chan_tests_enabled=$(jq --raw-output '.tests.enabled' <<< "${chan_config}") && \
-              echo "chan_tests_enabled=${chan_tests_enabled}" >> $GITHUB_OUTPUT
-          chan_tests_type=$(jq --raw-output '.tests.type' <<< "${chan_config}") && \
-              echo "chan_tests_type=${chan_tests_type}" >> $GITHUB_OUTPUT
+  build-platform-images:
+    name: Build/Test ${{ matrix.image.chan_image_name }} - ${{ matrix.image.platform }}
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    strategy:
+      matrix:
+        image: ["${{ fromJson(needs.prepare.outputs.matrices).imagePlatformPermutations }}"]
+      fail-fast: false
+    steps:
+      - name: Log Matrix Input
+        run: |
+          cat << EOF
+          ${{ toJSON(matrix.image) }}
+          EOF
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
 
-          chan_upstream_version=$(bash ./.github/scripts/upstream.sh "${{ matrix.image.app }}" "${{ matrix.image.channel }}") && \
-              echo "chan_upstream_version=${chan_upstream_version}" >> $GITHUB_OUTPUT
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-          if [[ "${chan_tests_enabled}" == true && "${chan_tests_type}" == "cli" ]]; then
-              echo "chan_goss_args=tail -f /dev/null" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "${container_base}" == true ]]; then
-              echo "chan_label_type=org.opencontainers.image.base" >> $GITHUB_OUTPUT
-          else
-              echo "chan_label_type=org.opencontainers.image" >> $GITHUB_OUTPUT
-          fi
-
-          if test -f "./apps/${{ matrix.image.app }}/${{ matrix.image.channel }}/Dockerfile"; then
-              echo "chan_dockerfile=./apps/${{ matrix.image.app }}/${{ matrix.image.channel }}/Dockerfile" >> $GITHUB_OUTPUT
-              echo "chan_goss_config=./apps/${{ matrix.image.app }}/${{ matrix.image.channel }}/goss.yaml" >> $GITHUB_OUTPUT
-          else
-              echo "chan_dockerfile=./apps/${{ matrix.image.app }}/Dockerfile" >> $GITHUB_OUTPUT
-              echo "chan_goss_config=./apps/${{ matrix.image.app }}/ci/goss.yaml" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "${chan_stable}" == true ]]; then
-              echo "chan_tag_testing=${{ matrix.image.app }}:testingz" >> $GITHUB_OUTPUT
-              echo "chan_tag_rolling=${{ matrix.image.app }}:rolling" >> $GITHUB_OUTPUT
-              echo "chan_tag_version=${{ matrix.image.app }}:${chan_upstream_version}" >> $GITHUB_OUTPUT
-          else
-              echo "chan_tag_testing=${{ matrix.image.app }}-${{ matrix.image.channel }}:testingz" >> $GITHUB_OUTPUT
-              echo "chan_tag_rolling=${{ matrix.image.app }}-${{ matrix.image.channel }}:rolling" >> $GITHUB_OUTPUT
-              echo "chan_tag_version=${{ matrix.image.app }}-${{ matrix.image.channel }}:${chan_upstream_version}" >> $GITHUB_OUTPUT
-          fi
+      - name: Setup GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Tools
         shell: bash
@@ -106,95 +91,140 @@ jobs:
         uses: cue-lang/setup-cue@0be332bb74c8a2f07821389447ba3163e2da3bfb
 
       - name: Setup Goss
-        if: ${{ steps.vars.outputs.chan_tests_enabled == 'true' }}
+        if: ${{ matrix.image.chan_tests_enabled }}
         uses: e1himself/goss-installation-action@v1.1.0
         with:
           version: v0.3.21
 
-      - name: Validate image metadata
+      - name: Prepare Build Outputs
+        id: prepare-build-outputs
+        run: |
+          if [[ ${{ inputs.pushImages }} == 'true' ]]; then
+              image_name="ghcr.io/${{ github.repository_owner }}/${{ matrix.image.chan_image_name }}"
+              outputs="type=image,name=${image_name},push-by-digest=true,name-canonical=true,push=true"
+          else
+              image_name="ghcr.io/${{ github.repository_owner }}/${{ matrix.image.chan_tag_testing }}"
+              outputs="type=docker,name=${image_name},push=false"
+          fi
+          echo "image_name=${image_name}" >> $GITHUB_OUTPUT
+          echo "outputs=${outputs}" >> $GITHUB_OUTPUT
+
+      - name: Build Image
+        uses: docker/build-push-action@v4
+        id: build
+        with:
+          build-args: |-
+            VERSION=${{ matrix.image.chan_upstream_version }}
+            CHANNEL=${{ matrix.image.channel }}
+          context: .
+          platforms: ${{ matrix.image.platform }}
+          file: ${{ matrix.image.chan_dockerfile }}
+          outputs: ${{ steps.prepare-build-outputs.outputs.outputs }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Goss Tests
+        id: dgoss
+        if: ${{ matrix.image.chan_tests_enabled }}
         shell: bash
-        run: cue vet --schema '#Spec' ./apps/${{ matrix.image.app }}/metadata.json ./metadata.rules.cue
+        env:
+          CONTAINER_RUNTIME: docker
+          GOSS_FILE: ${{ matrix.image.chan_goss_config }}
+          GOSS_OPTS: --retry-timeout 60s --sleep 2s --color --format documentation
+          GOSS_SLEEP: 2
+          GOSS_FILES_STRATEGY: cp
+          CONTAINER_LOG_OUTPUT: goss_container_log_output
+        run: |
+          if [[ '${{ inputs.pushImages }}' == 'true' ]]; then
+              image_name="${{ steps.prepare-build-outputs.outputs.image_name }}@${{ steps.build.outputs.digest }}"
+          else
+              image_name="${{ steps.prepare-build-outputs.outputs.image_name }}"
+          fi
+          dgoss run ${image_name} ${{ matrix.image.chan_goss_args }}
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+      - name: Export Digest
+        id: export-digest
+        if: ${{ inputs.pushImages == 'true' }}
+        run: |
+          mkdir -p /tmp/${{ matrix.image.chan_image_name }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/${{ matrix.image.chan_image_name }}/digests/${digest#sha256:}"
 
-      - name: Setup Docker Buildx
-        id: buildx
+      - name: Set Failed Bit
+        if: ${{ always() && steps.dgoss.outcome == 'failed' || steps.build.outcome != 'success' }}
+        run: |
+          touch "/tmp/${{ matrix.image.chan_image_name }}/failed"
+
+      - name: Upload Digest
+        if: ${{ inputs.push == 'true' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.image.chan_image_name }}
+          path: /tmp/${{ matrix.image.chan_image_name }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.manifest.image }}
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - build-platform-images
+    # Always run merge, as the prior matrix is all or nothing. We test for prior step failure
+    # in the "Test Failed Bit" step. This ensures if one app fails, others can still complete.
+    if: ${{ always() && inputs.pushImages == 'true' }}
+    strategy:
+      matrix:
+        manifest: ["${{ fromJSON(needs.prepare.outputs.matrices).manifestsToBuild }}"]
+      fail-fast: false
+    steps:
+      - name: Download Digests
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.manifest.image }}
+          path: /tmp/${{ matrix.manifest.image }}
+
+      - name: Test Failed Bit
+        id: failure-test
+        run:
+          test -f "/tmp/${{ matrix.manifest.image }}/failed" && exit 1 || exit 0
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Setup GHCR
-        if: ${{ inputs.pushImages == 'true' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build container image for testing
-        uses: docker/build-push-action@v4
-        with:
-          build-args: |-
-            VERSION=${{ steps.vars.outputs.chan_upstream_version }}
-            CHANNEL=${{ matrix.image.channel }}
-          context: .
-          platforms: linux/amd64 # load does not support muti-arch https://github.com/docker/buildx/issues/290
-          file: ${{ steps.vars.outputs.chan_dockerfile }}
-          load: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_testing }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Log Files
+        working-directory: /tmp/${{ matrix.manifest.image }}/digests
+        run: |
+          ls -la
+          cat *
 
-      - name: Run Goss tests
-        id: dgoss
-        if: ${{ steps.vars.outputs.chan_tests_enabled == 'true' }}
-        shell: bash
+      - name: Merge Manifests
+        id: merge
+        working-directory: /tmp/${{ matrix.manifest.image }}/digests
         env:
-          CONTAINER_RUNTIME: docker
-          GOSS_FILE: ${{ steps.vars.outputs.chan_goss_config }}
-          GOSS_OPTS: --retry-timeout 60s --sleep 2s --color --format documentation
-          GOSS_SLEEP: 2
-          GOSS_FILES_STRATEGY: cp
-          CONTAINER_LOG_OUTPUT: goss_container_log_output
-        run: dgoss run ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_testing }} ${{ steps.vars.outputs.chan_goss_args }}
-
-      - name: Build all platforms
-        id: release
-        uses: docker/build-push-action@v4
-        with:
-          build-args: |-
-            VERSION=${{ steps.vars.outputs.chan_upstream_version }}
-            CHANNEL=${{ matrix.image.channel }}
-          labels: |-
-            ${{ steps.vars.outputs.chan_label_type }}.created="${{ steps.vars.outputs.chan_build_date }}"
-            ${{ steps.vars.outputs.chan_label_type }}.title="${{ matrix.image.app }} (${{ matrix.image.channel }})"
-            ${{ steps.vars.outputs.chan_label_type }}.version="${{ steps.vars.outputs.chan_upstream_version }}"
-            ${{ steps.vars.outputs.chan_label_type }}.authors="Devin Buhl <onedr0p@users.noreply.github.com>"
-            ${{ steps.vars.outputs.chan_label_type }}.url="https://github.com/onedr0p/containers/apps/${{ matrix.image.app }}"
-            ${{ steps.vars.outputs.chan_label_type }}.build.url="https://github.com/onedr0p/containers/actions/runs/${{ github.run_id }}"
-            ${{ steps.vars.outputs.chan_label_type }}.documentation="https://github.com/onedr0p/containers/apps/${{ matrix.image.app }}/README.md"
-            ${{ steps.vars.outputs.chan_label_type }}.revision="${{ github.sha }}"
-          context: .
-          platforms: ${{ steps.vars.outputs.chan_platforms }}
-          file: ${{ steps.vars.outputs.chan_dockerfile }}
-          push: ${{ inputs.pushImages == 'true' }}
-          tags: |-
-            ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_rolling }}
-            ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          TAGS: ${{ toJSON(matrix.manifest.tags) }}
+        run:
+          docker buildx imagetools create $(jq -cr '. | map("-t ghcr.io/${{ github.repository_owner }}/" + .) | join(" ")'  <<< "$TAGS") $(printf 'ghcr.io/${{ github.repository_owner }}/${{ matrix.manifest.image }}@sha256:%s ' *)
 
       - name: Build successful
         id: build-success
-        if: ${{ always() && steps.release.outcome == 'success' }}
+        if: ${{ always() && steps.merge.outcome == 'success' && steps.failure-test.outcome == 'success' }}
         run: |-
-          echo "message=🎉 ${{ matrix.image.app }}-${{ matrix.image.channel }} (${{ steps.vars.outputs.chan_upstream_version }})" >> $GITHUB_OUTPUT
+          echo "message=🎉 ${{ matrix.manifest.app }}-${{ matrix.manifest.channel }} (${{ matrix.manifest.version }})" >> $GITHUB_OUTPUT
           echo "color=0x00FF00" >> $GITHUB_OUTPUT
 
       - name: Build failed
         id: build-failed
-        if: ${{ always() && (steps.release.outcome == 'failure' || steps.dgoss.outcome == 'failure') }}
+        if: ${{ always() && (steps.merge.outcome == 'failure' || steps.failure-test.outcome == 'failure') }}
         run: |-
-          echo "message=💥 ${{ matrix.image.app }}-${{ matrix.image.channel }} (${{ steps.vars.outputs.chan_upstream_version }})" >> $GITHUB_OUTPUT
+          echo "message=💥 ${{ matrix.manifest.app }}-${{ matrix.manifest.channel }} (${{ matrix.manifest.version }})" >> $GITHUB_OUTPUT
           echo "color=0xFF0000" >> $GITHUB_OUTPUT
 
       - name: Send Discord Webhook
@@ -203,7 +233,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ steps.build-failed.outputs.message || steps.build-success.outputs.message }}
-          color: ${{ steps.build-failed.outputs.color }}
+          color: ${{ steps.build-failed.outputs.color || steps.build-success.outputs.color }}
           username: GitHub Actions
 
   # Summarize matrix https://github.community/t/status-check-for-a-matrix-jobs/127354/7
@@ -211,9 +241,9 @@ jobs:
     name: Build matrix success
     runs-on: ubuntu-latest
     needs:
-      - build-and-test
+      - merge
     if: ${{ always() }}
     steps:
       - name: Check build matrix status
-        if: ${{ (inputs.imagesToBuild != '' && inputs.imagesToBuild != '[]') && (needs.build-and-test.result != 'success') }}
+        if: ${{ (inputs.imagesToBuild != '' && inputs.imagesToBuild != '[]') && (needs.merge.result != 'success' && needs.merge.result != 'skipped') }}
         run: exit 1

--- a/.github/workflows/image-rebuild.yaml
+++ b/.github/workflows/image-rebuild.yaml
@@ -24,8 +24,8 @@ jobs:
         id: collect-changes
         uses: ./.github/actions/collect-changes
 
-  generate-build-matrix:
-    name: Generate matrix for building images
+  determine-images:
+    name: Determine Images to Build
     runs-on: ubuntu-latest
     needs: ["get-changes"]
     outputs:
@@ -60,9 +60,8 @@ jobs:
   images-build:
     uses: onedr0p/containers/.github/workflows/action-image-build.yaml@main
     needs:
-      - generate-build-matrix
+      - determine-images
     with:
-      imagesToBuild: "${{ needs.generate-build-matrix.outputs.matrix }}"
+      imagesToBuild: "${{ needs.determine-images.outputs.matrix }}"
       pushImages: "true"
-      updateMetadata: "true"
     secrets: inherit

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -52,5 +52,4 @@ jobs:
     needs: ["generate-build-matrix"]
     with:
       imagesToBuild: "${{ needs.generate-build-matrix.outputs.matrix }}"
-      updateMetadata: "false"
     secrets: inherit

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -25,11 +25,11 @@ env:
   TOKEN: ${{ secrets.TOKEN }}
 
 jobs:
-  generate-build-matrix:
-    name: Generate matrix for building images
+  determine-images:
+    name: Determine Images to Build
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.determine-images.outputs.changes }}
+      imagesToBuild: ${{ steps.determine-images.outputs.changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -54,14 +54,14 @@ jobs:
 
             output="$(jo -a ${images_array[*]})"
             echo "changes=${output}" >> $GITHUB_OUTPUT
+            echo "Changes:\n ${output}"
           fi
 
   images-build:
-    uses: onedr0p/containers/.github/workflows/action-image-build.yaml@main
-    if: needs.generate-build-matrix.outputs.matrix != '[]'
-    needs: ["generate-build-matrix"]
+    uses: ./.github/workflows/action-image-build.yaml
+    if: needs.determine-images.outputs.imagesToBuild != '[]'
+    needs: ["determine-images"]
     with:
-      imagesToBuild: "${{ needs.generate-build-matrix.outputs.matrix }}"
+      imagesToBuild: "${{ needs.determine-images.outputs.imagesToBuild }}"
       pushImages: "${{ github.event.inputs.push }}"
-      updateMetadata: "${{ github.event.inputs.push }}"
     secrets: inherit

--- a/.github/workflows/release-schedule.yaml
+++ b/.github/workflows/release-schedule.yaml
@@ -14,11 +14,11 @@ env:
   TOKEN: ${{ secrets.TOKEN }}
 
 jobs:
-  generate-build-matrix:
-    name: Generate matrix for building images
+  determine-images:
+    name: Determine Images to Build
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.fetch.outputs.changes }}
+      imagesToBuild: ${{ steps.fetch.outputs.changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -41,11 +41,10 @@ jobs:
 
   images-build:
     uses: onedr0p/containers/.github/workflows/action-image-build.yaml@main
-    if: needs.generate-build-matrix.outputs.matrix != '[]'
-    needs: ["generate-build-matrix"]
+    if: needs.determine-images.outputs.imagesToBuild != '[]'
+    needs: ["determine-images"]
     with:
-      imagesToBuild: "${{ needs.generate-build-matrix.outputs.matrix }}"
+      imagesToBuild: "${{ needs.determine-images.outputs.imagesToBuild }}"
       pushImages: "true"
-      updateMetadata: "true"
       sendNotification: "true"
     secrets: inherit


### PR DESCRIPTION
Currently, the image publish action matrixes across all the image/channel combinations to build and publish their images. In each case, the image is built first for only `amd64`, and tested with goss, and then built again multi-arch. There are two improvements that can be made here:

1. Don't repeat the build, leverage the actual production build for goss testing
2. Matrix the platforms so the different platforms are not competing for the same resources in the runner.

This PR accomplishes both, the workflow now looks like:
1. Determine Images that should be built (unchanged)
2. Generate an app,channel,platform matrix, and an app,channel matrix. The former also contains all variables we previously generated inside the workflow.
3. Run all platform builds in parallel using the app,channel,platform matrix, and if push is enabled, push them by digest to ghcr.
4. Run a merge step using the app,channel matrix, which collects all digests for each image/platform from artifact storage, and creates and pushes a multi-arch manifest which stitches them together

For testing, the matrix ignores all arm64 builds, and runs tests against a local image built amd64 (logic is changed, the end result is the same).

A few test runs:

Ubuntu Image, (base image) with push set to true:
https://github.com/rtrox/containers/actions/runs/5283036363

Ubuntu image with push set to false (dgoss test only):
https://github.com/rtrox/containers/actions/runs/5283095678

Home Assistant build for speed comparison:
https://github.com/rtrox/containers/actions/runs/5280361520

Concerns:

I'm really only able to test via Manual Release, and as a result, I've only tested against one image/channel combination. I've planned around multiple -- the digests are stored by their app/channel combination, and in the merge step, it's set to run `always()`, but fail a particular matrix if any platform build generated a `failed` file, so it should be good, but there's some risk there. If anything pops up in the first scheduled run, I'm glad to jump on it to debug.

