### PR TITLE
Restore Cue Validation

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -49,6 +49,15 @@ jobs:
           echo 'pushImages=${{ inputs.pushImages }}'
           echo 'sendNotification=${{ inputs.sendNotification }}'
 
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@0be332bb74c8a2f07821389447ba3163e2da3bfb
+
+      - name: Validate Image Metadata
+        shell: bash
+        # 'xargs' rather than 'find -exec' so we can capture the status code
+        run: |
+          find ./apps/ -name metadata.json | xargs -I {} cue vet --schema '#Spec' {} ./metadata.rules.cue
+
       - name: Generate Matrices
         id: generate-matrices
         run: |
@@ -87,9 +96,6 @@ jobs:
       - name: Setup Tools
         shell: bash
         run: sudo apt-get install -y moreutils jo
-
-      - name: Setup CUE
-        uses: cue-lang/setup-cue@0be332bb74c8a2f07821389447ba3163e2da3bfb
 
       - name: Setup Goss
         if: ${{ matrix.image.chan_tests_enabled }}


### PR DESCRIPTION
Per Title. I'd apparently accidentally removed the cue validation step :-/

Since the metadata is important to generate the matrices now, I put Cue into the Prepare step. It's tough to fully test github actions, but I was able to run the validation command locally (captured below).

Failed Validation:
```bash
~/onedr0p-containers ❯❯❯ find ./apps/ -name metadata.json | xargs -I {} cue vet --schema '#Spec' {} ./metadata.rules.cue
channels.0.asdf: field not allowed:
    ./apps/emby/metadata.json:16:7
    ./metadata.rules.cue:1:8
    ./metadata.rules.cue:4:13
    ./metadata.rules.cue:4:16
    ./metadata.rules.cue:7:12
~/onedr0p-containers ❯❯❯ echo $?
123
```

Successful Validation:
```bash
~/onedr0p-containers ❯❯❯ find ./apps/ -name metadata.json | xargs -I {} cue vet --schema '#Spec' {} ./metadata.rules.cue                                                                                                                                                         ✘ 123
~/onedr0p-containers ❯❯❯ echo $?
0
```

