### PR TITLE
Failed bit

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -49,6 +49,15 @@ jobs:
           echo 'pushImages=${{ inputs.pushImages }}'
           echo 'sendNotification=${{ inputs.sendNotification }}'
 
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@0be332bb74c8a2f07821389447ba3163e2da3bfb
+
+      - name: Validate Image Metadata
+        shell: bash
+        # 'xargs' rather than 'find -exec' so we can capture the status code
+        run: |
+          find ./apps/ -name metadata.json | xargs -I {} cue vet --schema '#Spec' {} ./metadata.rules.cue
+
       - name: Generate Matrices
         id: generate-matrices
         run: |
@@ -87,9 +96,6 @@ jobs:
       - name: Setup Tools
         shell: bash
         run: sudo apt-get install -y moreutils jo
-
-      - name: Setup CUE
-        uses: cue-lang/setup-cue@0be332bb74c8a2f07821389447ba3163e2da3bfb
 
       - name: Setup Goss
         if: ${{ matrix.image.chan_tests_enabled }}

--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -158,7 +158,7 @@ jobs:
           touch "/tmp/${{ matrix.image.chan_image_name }}/digests/${digest#sha256:}"
 
       - name: Set Failed Bit
-        if: ${{ always() && steps.dgoss.outcome == 'failed' || steps.build.outcome != 'success' }}
+        if: ${{ always() && steps.dgoss.outcome == 'failure' || steps.build.outcome != 'success' }}
         run: |
           mkdir -p /tmp/${{ matrix.image.chan_image_name }}
           touch "/tmp/${{ matrix.image.chan_image_name }}/failed"


### PR DESCRIPTION
(Merge Cue PR first)

outcome is "failure" not "failed" when a step fails. Without this fix, Goss failures will fail the amd64 build, but will not set the failed bit, leading to containers that only have arm64 builds attached