### PR TITLE
fix(ci): Ensure failed bit gets uploaded

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -164,7 +164,7 @@ jobs:
           touch "/tmp/${{ matrix.image.chan_image_name }}/failed"
 
       - name: Upload Digest
-        if: ${{ inputs.pushImages == 'true' }}
+        if: ${{ always() inputs.pushImages == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.image.chan_image_name }}


### PR DESCRIPTION
Quick hotfix to ensure the failed bit gets checked. This is obviously still a bit brittle, I'll spend some time today looking for a more robust way to do this.