### PR TITLE
Test platform count rather than failed bit

### DIFF
--- a/.github/scripts/prepare-images.py
+++ b/.github/scripts/prepare-images.py
@@ -84,6 +84,7 @@ if __name__ == "__main__":
             "app": name,
             "channel": channel,
             "tags": [app["chan_tag_rolling"], app["chan_tag_version"]],
+            "platforms": cfg["platforms"],
             "version": app["chan_upstream_version"],
         }
         out["manifestsToBuild"].append(manifest)

--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -155,16 +155,10 @@ jobs:
         run: |
           mkdir -p /tmp/${{ matrix.image.chan_image_name }}/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/${{ matrix.image.chan_image_name }}/digests/${digest#sha256:}"
-
-      - name: Set Failed Bit
-        if: ${{ always() && steps.dgoss.outcome == 'failure' || steps.build.outcome != 'success' }}
-        run: |
-          mkdir -p /tmp/${{ matrix.image.chan_image_name }}
-          touch "/tmp/${{ matrix.image.chan_image_name }}/failed"
+          echo "${{ matrix.image.platform }}" > "/tmp/${{ matrix.image.chan_image_name }}/digests/${digest#sha256:}"
 
       - name: Upload Digest
-        if: ${{ always() && inputs.pushImages == 'true' }}
+        if: ${{ inputs.pushImages == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.image.chan_image_name }}
@@ -192,10 +186,17 @@ jobs:
           name: ${{ matrix.manifest.image }}
           path: /tmp/${{ matrix.manifest.image }}
 
-      - name: Test Failed Bit
-        id: failure-test
-        run:
-          test -f "/tmp/${{ matrix.manifest.image }}/failed" && exit 1 || exit 0
+      - name: Ensure all platforms were built
+        id: ensure-platforms
+        run: |
+            EXPECTED_COUNT = $(echo "${{ toJSON(matrix.manifest.platforms) }}" | jq ". | length")
+            ACTUAL_COUNT = $(ls -1 /tmp/${{ matrix.manifest.image }}/digests | wc -l)
+            if [[ $EXPECTED_COUNT != $ACTUAL_COUNT ]]; then
+                echo "Expected $EXPECTED_COUNT platforms, but only found $ACTUAL_COUNT"
+                echo "Expected: ${{ toJSON(matrix.manifest.platforms) }}"
+                echo "Actual: $(cat /tmp/${{ matrix.manifest.image }}/digests/*)"
+                exit 1
+            fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
This PR should be a bit more permanent fix to failure checking. No instead of counting on the upload of a "failed" file we test for, instead we just compare the count of platforms to the count of digests, and if they don't match, we bail.

As always, there isn't really a good way for me to test this pre-merge, so please look carefully :-D We can run a manual release after merge to test it.