### PR TITLE
(lidarr): add plugins branch container

### DIFF
--- a/apps/lidarr/metadata.json
+++ b/apps/lidarr/metadata.json
@@ -37,6 +37,18 @@
         "enabled": true,
         "type": "web"
       }
+    },
+    {
+      "name": "plugins",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "stable": false,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
     }
   ]
 }


### PR DESCRIPTION
This allows building of the `plugins` branch which is useful for developing and adding plugins to Lidarr. Considering that this branch has yet to make it to main and may or may not get merged anytime soon, i have opted to leave it designated as unstable.

thanks!