### PR TITLE
[#911] fix: add `findutils` to transmission image.

### DIFF
--- a/apps/transmission/Dockerfile
+++ b/apps/transmission/Dockerfile
@@ -11,7 +11,7 @@ ENV HOME=/config \
     TRANSMISSION_WEB_HOME=/app/web
 
 #hadolint ignore=DL3018
-RUN apk add --no-cache ca-certificates geoip p7zip python3 \
+RUN apk add --no-cache ca-certificates findutils geoip p7zip python3 \
     transmission-cli~"${VERSION}" transmission-daemon~"${VERSION}"
 
 #hadolint ignore=DL3059


### PR DESCRIPTION
This should fix #911 - adds the gnu version of `find` which appears to be required by transmission's default `post-process.sh` script.

fixes #911 