### PR TITLE
fix: release-scheduled permissions

### DIFF
--- a/.github/workflows/release-scheduled.yaml
+++ b/.github/workflows/release-scheduled.yaml
@@ -32,6 +32,7 @@ jobs:
     uses: onedr0p/containers/.github/workflows/build-images.yaml@main
     secrets: inherit
     permissions:
+      contents: read
       packages: write
     with:
       appsToBuild: ${{ inputs.appsToBuild }}


### PR DESCRIPTION
Since a few days the scheduled release is not working as intended, the build image job should be called with a new permission.