### PR TITLE
create talosctl-alpine tool image

### DIFF
--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -10,6 +10,7 @@ on:
     branches: ["main"]
     paths:
       - "apps/**"
+      - ".github/workflows/**"
       - ".github/scripts/templates/**"
       - "!apps/**/metadata.json"
       - "!apps/**/metadata.yaml"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,14 +16,14 @@ tasks:
     cmds:
       - task: download-goss
       - >-
-        cue vet --schema '#Spec' ./apps/{{.APP}}/metadata.json metadata.rules.cue
+        cue vet --schema '#Spec' ./apps/{{.APP}}/metadata.yaml metadata.rules.cue
       - >-
         docker buildx build --progress=plain --load
         -t {{.APP}}:{{.CHANNEL}}
         --build-arg CHANNEL={{.CHANNEL}}
-        --build-arg VERSION=$(bash ./.github/scripts/upstream.sh "{{.APP}}" "{{.CHANNEL}}")
+        --build-arg VERSION=$(bash ./apps/"{{.APP}}"/ci/latest.sh "{{.CHANNEL}}")
         {{if eq .MULTIPLATFORM "true"}}
-        --platform $(jq -r '.channels[] | select(.name=="{{.CHANNEL}}").platforms | join(",")' ./apps/{{.APP}}/metadata.json)
+        --platform $(jq -r '.channels[] | select(.name=="{{.CHANNEL}}").platforms | join(",")' ./apps/{{.APP}}/metadata.yaml)
         {{else}}
         --platform "linux/$(uname -m | sed 's/x86_64/amd64/')"
         {{end}}
@@ -39,6 +39,7 @@ tasks:
       GOSS_FILES_STRATEGY: cp
     vars:
       MULTIPLATFORM: '{{ default "false" .MULTIPLATFORM }}'
+      sh: bash ./apps/"{{.APP}}"/ci/latest.sh "{{.CHANNEL}}"
 
   download-goss:
     silent: true

--- a/apps/talosctl-alpine/Dockerfile
+++ b/apps/talosctl-alpine/Dockerfile
@@ -1,0 +1,11 @@
+ARG TARGETPLATFORM
+ARG VERSION
+ARG CHANNEL
+FROM --platform=${TARGETPLATFORM} ghcr.io/siderolabs/talosctl:${VERSION} as talosctl
+FROM ghcr.io/onedr0p/alpine:rolling@sha256:0e3067295cc20dafbd4cf63789ccc71858ad555f3998200ca10b271328c7285e
+
+COPY --from=talosctl /talosctl /usr/local/bin/talosctl
+
+ENTRYPOINT [ "/usr/local/bin/talosctl" ]
+
+LABEL org.opencontainers.image.source="https://github.com/siderolabs/talos"

--- a/apps/talosctl-alpine/ci/goss.yaml
+++ b/apps/talosctl-alpine/ci/goss.yaml
@@ -1,0 +1,6 @@
+---
+file:
+  /usr/local/bin/talosctl:
+    exists: true
+  /usr/bin/jq:
+    exists: true

--- a/apps/talosctl-alpine/ci/latest.sh
+++ b/apps/talosctl-alpine/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/siderolabs/talos/releases/latest" | jq --raw-output '.tag_name' 2>/dev/null)
+version="${version#*release-}"
+printf "%s" "${version}"

--- a/apps/talosctl-alpine/metadata.yaml
+++ b/apps/talosctl-alpine/metadata.yaml
@@ -1,0 +1,10 @@
+---
+app: talosctl-alpine
+base: true
+channels:
+  - name: talosctl
+    platforms: ["linux/amd64", "linux/arm64"]
+    stable: false
+    tests:
+      enabled: true
+      type: cli


### PR DESCRIPTION
This adds `./apps/talosctl-alpine` which is essentially the same as `ghcr.io/siderolabs/talosctl` except it uses alpine as a base image instead of scratch. This means basic shells and tools exist for scripting purposes around talosctl. This makes it ideal for custom scriptable [System Upgrade Controller](https://github.com/rancher/system-upgrade-controller) job runners targeting [Talos Kubernetes](https://github.com/siderolabs/talos) clusters. It can be used within a system upgrade plan, as the job images via `.spec.prepare.image` and `.spec.upgrade.image` since its tags should closely align with the same tags that would be published for `ghcr.io/siderolabs/talosctl`.

Infact, this image can be a drop-in replacement for `ghcr.io/siderolabs/talosctl` because the entrypoint is still the `talosctl` binary itself. You just gain the ability to use shell scripting when overriding the entrypoing with `/bin/sh` or any other available shell in `ghcr.io/onedr0p/alpine`

<details><summary>example usage with inline entrypoint override:</summary>

```
...
spec:
  # renovate: datasource=github-releases depName=siderolabs/talos
  version: v1.6.5
  prepare:
    image: ghcr.io/onedr0p/talosctl-alpine
    envs:
      - name: NODE_IP
        valueFrom:
          fieldRef:
            fieldPath: status.hostIP
    args:
      - --nodes=$(NODE_IP)
      - health
      - --server=false
  upgrade:
    image: ghcr.io/onedr0p/talosctl-alpine
    envs:
      - name: NODE_IP
        valueFrom:
          fieldRef:
            fieldPath: status.hostIP
      - name: UPGRADE_IMAGE
        value: ghcr.io/siderolabs/installer
    command:
    - /bin/sh
    - -c
    - |
      # inline script goes here, treat this like a for loop! 
      # your upgrade command will 99% of the time get interrupted by the node rebooting
      # and this script will start over when it boots back up. 
      # So your pre-upgrade checks will also be your post-upgrade checks!
      <perform checks>
      <do upgrade>
```
</details>

## Background

Initially, I wanted to try to use `ghcr.io/siderolabs/talosctl` image as the SuC runner image for some custom logic/behavior but the talosctl image does not contain any shells and is just the binary on a scratch image. You could switch to something like an alpine image for `/bin/sh`, but now you need to install the talosctl binary and that can be a somewhat fragile process.

So this image packages talosctl with alpine as a base, to make sure that a shell is available. And now we can use it to customize our system upgrade plans as we please.