### PR TITLE
Add mediainfo back to image

### DIFF
--- a/apps/bazarr/Dockerfile
+++ b/apps/bazarr/Dockerfile
@@ -22,7 +22,7 @@ RUN \
 
 #hadolint ignore=DL3018,DL3013
 RUN \
-    apk add --no-cache ca-certificates ffmpeg python3 py3-lxml py3-numpy py3-gevent py3-cryptography py3-setuptools py3-psycopg2 py3-pillow unzip \
+    apk add --no-cache ca-certificates ffmpeg mediainfo python3 py3-lxml py3-numpy py3-gevent py3-cryptography py3-setuptools py3-psycopg2 py3-pillow unzip \
     && \
     apk add --no-cache --virtual .build-deps py3-pip gcc python3-dev musl-dev \
     && \


### PR DESCRIPTION
If you're currently analyzing track language, missing mediainfo will cause rescan tasks to hang indefinitely, preventing an update or sync of the backends. This appears to have been removed in the 1.4.2 release.