### PR TITLE
feat(radarr, sonarr, prowlarr): Allow disabling log db

### DIFF
--- a/apps/prowlarr/README.md
+++ b/apps/prowlarr/README.md
@@ -16,6 +16,7 @@ This container support setting certain custom enviroment variables with the use 
 | PROWLARR__PORT                    | `9696`              |
 | PROWLARR__POSTGRES_HOST           |                     |
 | PROWLARR__POSTGRES_MAIN_DB        |                     |
+| PROWLARR__POSTGRES_LOG_DB_ENABLED | `True`              |
 | PROWLARR__POSTGRES_LOG_DB         |                     |
 | PROWLARR__POSTGRES_PASSWORD       |                     |
 | PROWLARR__POSTGRES_PORT           | `5432`              |

--- a/apps/prowlarr/config.xml.tmpl
+++ b/apps/prowlarr/config.xml.tmpl
@@ -11,6 +11,7 @@
   <PostgresPort>${PROWLARR__POSTGRES_PORT:-5432}</PostgresPort>
   <PostgresHost>${PROWLARR__POSTGRES_HOST}</PostgresHost>
   <PostgresMainDb>${PROWLARR__POSTGRES_MAIN_DB}</PostgresMainDb>
+  <LogDbEnabled>${PROWLARR__POSTGRES_LOG_DB_ENABLED:-True}</LogDbEnabled>
   <PostgresLogDb>${PROWLARR__POSTGRES_LOG_DB}</PostgresLogDb>
   <Port>${PROWLARR__PORT}</Port>
   <BindAddress>*</BindAddress>

--- a/apps/prowlarr/entrypoint.sh
+++ b/apps/prowlarr/entrypoint.sh
@@ -15,6 +15,7 @@ if [[ -f /config/config.xml ]]; then
     current_postgres_port="$(xmlstarlet sel -t -v "//PostgresPort" -nl /config/config.xml)"
     current_postgres_host="$(xmlstarlet sel -t -v "//PostgresHost" -nl /config/config.xml)"
     current_postgres_main_db="$(xmlstarlet sel -t -v "//PostgresMainDb" -nl /config/config.xml)"
+    current_postgres_log_db_enabled="$(xmlstarlet sel -t -v "//LogDbEnabled" -nl /config/config.xml)"
     current_postgres_log_db="$(xmlstarlet sel -t -v "//PostgresLogDb" -nl /config/config.xml)"
     current_theme="$(xmlstarlet sel -t -v "//Theme" -nl /config/config.xml)"
 fi
@@ -36,6 +37,7 @@ envsubst < /app/config.xml.tmpl > /config/config.xml
 [[ -z "${PROWLARR__POSTGRES_PORT}" && -n "${current_postgres_port}" ]] && xmlstarlet edit --inplace --update //PostgresPort -v "${current_postgres_port}" /config/config.xml
 [[ -z "${PROWLARR__POSTGRES_HOST}" && -n "${current_postgres_host}" ]] && xmlstarlet edit --inplace --update //PostgresHost -v "${current_postgres_host}" /config/config.xml
 [[ -z "${PROWLARR__POSTGRES_MAIN_DB}" &&  -n "${current_postgres_main_db}" ]] && xmlstarlet edit --inplace --update //PostgresMainDb -v "${current_postgres_main_db}" /config/config.xml
+[[ -z "${PROWLARR__POSTGRES_LOG_DB_ENABLED}" && -n "${current_postgres_log_db_enabled}" ]] && xmlstarlet edit --inplace --update //LogDbEnabled -v "${current_postgres_log_db_enabled}" /config/config.xml
 [[ -z "${PROWLARR__POSTGRES_LOG_DB}" && -n "${current_postgres_log_db}" ]] && xmlstarlet edit --inplace --update //PostgresLogDb -v "${current_postgres_log_db}" /config/config.xml
 [[ -z "${PROWLARR__THEME}" && -n "${current_theme}" ]] && xmlstarlet edit --inplace --update //Theme -v "${current_theme}" /config/config.xml
 

--- a/apps/radarr/README.md
+++ b/apps/radarr/README.md
@@ -16,6 +16,7 @@ This container support setting certain custom enviroment variables with the use 
 | RADARR__PORT                    | `7878`              |
 | RADARR__POSTGRES_HOST           |                     |
 | RADARR__POSTGRES_MAIN_DB        |                     |
+| RADARR__POSTGRES_LOG_DB_ENABLED | `True`              |
 | RADARR__POSTGRES_LOG_DB         |                     |
 | RADARR__POSTGRES_PASSWORD       |                     |
 | RADARR__POSTGRES_PORT           | `5432`              |

--- a/apps/radarr/config.xml.tmpl
+++ b/apps/radarr/config.xml.tmpl
@@ -11,6 +11,7 @@
   <PostgresPort>${RADARR__POSTGRES_PORT:-5432}</PostgresPort>
   <PostgresHost>${RADARR__POSTGRES_HOST}</PostgresHost>
   <PostgresMainDb>${RADARR__POSTGRES_MAIN_DB}</PostgresMainDb>
+  <LogDbEnabled>${RADARR__POSTGRES_LOG_DB_ENABLED:-True}</LogDbEnabled>
   <PostgresLogDb>${RADARR__POSTGRES_LOG_DB}</PostgresLogDb>
   <Port>${RADARR__PORT}</Port>
   <BindAddress>*</BindAddress>

--- a/apps/radarr/entrypoint.sh
+++ b/apps/radarr/entrypoint.sh
@@ -10,6 +10,7 @@ if [[ -f /config/config.xml ]]; then
     current_instance_name="$(xmlstarlet sel -t -v "//InstanceName" -nl /config/config.xml)"
     current_log_level="$(xmlstarlet sel -t -v "//LogLevel" -nl /config/config.xml)"
     current_postgres_host="$(xmlstarlet sel -t -v "//PostgresHost" -nl /config/config.xml)"
+    current_postgres_log_db_enabled="$(xmlstarlet sel -t -v "//LogDbEnabled" -nl /config/config.xml)"
     current_postgres_log_db="$(xmlstarlet sel -t -v "//PostgresLogDb" -nl /config/config.xml)"
     current_postgres_main_db="$(xmlstarlet sel -t -v "//PostgresMainDb" -nl /config/config.xml)"
     current_postgres_password="$(xmlstarlet sel -t -v "//PostgresPassword" -nl /config/config.xml)"
@@ -31,6 +32,7 @@ envsubst < /app/config.xml.tmpl > /config/config.xml
 [[ -z "${RADARR__INSTANCE_NAME}" && -n "${current_instance_name}" ]] && xmlstarlet edit --inplace --update //InstanceName -v "${current_instance_name}" /config/config.xml
 [[ -z "${RADARR__LOG_LEVEL}" && -n "${current_log_level}" ]] && xmlstarlet edit --inplace --update //LogLevel -v "${current_log_level}" /config/config.xml
 [[ -z "${RADARR__POSTGRES_HOST}" && -n "${current_postgres_host}" ]] && xmlstarlet edit --inplace --update //PostgresHost -v "${current_postgres_host}" /config/config.xml
+[[ -z "${RADARR__POSTGRES_LOG_DB_ENABLED}" && -n "${current_postgres_log_db_enabled}" ]] && xmlstarlet edit --inplace --update //LogDbEnabled -v "${current_postgres_log_db_enabled}" /config/config.xml
 [[ -z "${RADARR__POSTGRES_LOG_DB}" && -n "${current_postgres_log_db}" ]] && xmlstarlet edit --inplace --update //PostgresLogDb -v "${current_postgres_log_db}" /config/config.xml
 [[ -z "${RADARR__POSTGRES_MAIN_DB}" &&  -n "${current_postgres_main_db}" ]] && xmlstarlet edit --inplace --update //PostgresMainDb -v "${current_postgres_main_db}" /config/config.xml
 [[ -z "${RADARR__POSTGRES_PASSWORD}" && -n "${current_postgres_password}" ]] && xmlstarlet edit --inplace --update //PostgresPassword -v "${current_postgres_password}" /config/config.xml

--- a/apps/sonarr/README.md
+++ b/apps/sonarr/README.md
@@ -16,6 +16,7 @@ This container support setting certain custom enviroment variables with the use 
 | SONARR__PORT                    | `8989`              |
 | SONARR__POSTGRES_HOST           |                     |
 | SONARR__POSTGRES_MAIN_DB        |                     |
+| SONARR__POSTGRES_LOG_DB_ENABLED | `True`              |
 | SONARR__POSTGRES_LOG_DB         |                     |
 | SONARR__POSTGRES_PASSWORD       |                     |
 | SONARR__POSTGRES_PORT           | `5432`              |

--- a/apps/sonarr/config.xml.tmpl
+++ b/apps/sonarr/config.xml.tmpl
@@ -11,6 +11,7 @@
   <PostgresPort>${SONARR__POSTGRES_PORT:-5432}</PostgresPort>
   <PostgresHost>${SONARR__POSTGRES_HOST}</PostgresHost>
   <PostgresMainDb>${SONARR__POSTGRES_MAIN_DB}</PostgresMainDb>
+  <LogDbEnabled>${SONARR__POSTGRES_LOG_DB_ENABLED:-True}</LogDbEnabled>
   <PostgresLogDb>${SONARR__POSTGRES_LOG_DB}</PostgresLogDb>
   <Port>${SONARR__PORT}</Port>
   <BindAddress>*</BindAddress>

--- a/apps/sonarr/entrypoint.sh
+++ b/apps/sonarr/entrypoint.sh
@@ -15,6 +15,7 @@ if [[ -f /config/config.xml ]]; then
     current_postgres_port="$(xmlstarlet sel -t -v "//PostgresPort" -nl /config/config.xml)"
     current_postgres_host="$(xmlstarlet sel -t -v "//PostgresHost" -nl /config/config.xml)"
     current_postgres_main_db="$(xmlstarlet sel -t -v "//PostgresMainDb" -nl /config/config.xml)"
+    current_postgres_log_db_enabled="$(xmlstarlet sel -t -v "//LogDbEnabled" -nl /config/config.xml)"
     current_postgres_log_db="$(xmlstarlet sel -t -v "//PostgresLogDb" -nl /config/config.xml)"
     current_theme="$(xmlstarlet sel -t -v "//Theme" -nl /config/config.xml)"
 fi
@@ -36,6 +37,7 @@ envsubst < /app/config.xml.tmpl > /config/config.xml
 [[ -z "${SONARR__POSTGRES_PORT}" && -n "${current_postgres_port}" ]] && xmlstarlet edit --inplace --update //PostgresPort -v "${current_postgres_port}" /config/config.xml
 [[ -z "${SONARR__POSTGRES_HOST}" && -n "${current_postgres_host}" ]] && xmlstarlet edit --inplace --update //PostgresHost -v "${current_postgres_host}" /config/config.xml
 [[ -z "${SONARR__POSTGRES_MAIN_DB}" &&  -n "${current_postgres_main_db}" ]] && xmlstarlet edit --inplace --update //PostgresMainDb -v "${current_postgres_main_db}" /config/config.xml
+[[ -z "${SONARR__POSTGRES_LOG_DB_ENABLED}" && -n "${current_postgres_log_db_enabled}" ]] && xmlstarlet edit --inplace --update //LogDbEnabled -v "${current_postgres_log_db_enabled}" /config/config.xml
 [[ -z "${SONARR__POSTGRES_LOG_DB}" && -n "${current_postgres_log_db}" ]] && xmlstarlet edit --inplace --update //PostgresLogDb -v "${current_postgres_log_db}" /config/config.xml
 [[ -z "${SONARR__THEME}" && -n "${current_theme}" ]] && xmlstarlet edit --inplace --update //Theme -v "${current_theme}" /config/config.xml
 


### PR DESCRIPTION
As https://github.com/Radarr/Radarr/issues/9110 is closed, it would be nice to be able to disable the log databases of sonarr, radarr and prowlarr using environment variables.