### PR TITLE
Fix several HASS issues

### DIFF
--- a/apps/home-assistant/Dockerfile
+++ b/apps/home-assistant/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /app
 RUN \
     apk add --no-cache \
         bash \
+        binutils \
         bluez \
         bluez-deprecated \
         bluez-libs \
@@ -36,7 +37,8 @@ RUN \
         git \
         jq \
         libcap \
-        libturbojpeg \
+        libjpeg-turbo-dev \
+        libpcap-dev \
         libstdc++ \
         libxslt \
         mariadb-connector-c \

--- a/apps/home-assistant/Dockerfile
+++ b/apps/home-assistant/Dockerfile
@@ -35,6 +35,7 @@ RUN \
         eudev-libs \
         ffmpeg \
         git \
+        iputils \
         jq \
         libcap \
         libjpeg-turbo-dev \


### PR DESCRIPTION
Fixes:

- missing libturbojpeg and libpcap (context: https://github.com/onedr0p/containers/issues/1063)
- ICMP component failing due to ping requiring root ([solution source](https://serverfault.com/questions/1001174/cant-ping-permission-denied))
