### PR TITLE
feat: install python3 in qbittorrent

### DIFF
--- a/apps/qbittorrent/Dockerfile
+++ b/apps/qbittorrent/Dockerfile
@@ -30,6 +30,8 @@ RUN \
         jq \
         nano \
         p7zip \
+        python3 \
+        py3-pip \
         qt6-qtbase \
         qt6-qtbase-sqlite \
         trurl \


### PR DESCRIPTION
qBittorrent relies on python to run search plugins.