### PR TITLE
Fix HTML link in render-readme.py

### DIFF
--- a/scripts/render-readme.py
+++ b/scripts/render-readme.py
@@ -40,7 +40,7 @@ def process_metadata(apps_dir):
             image = {
                 "name": name,
                 "channel": channel["name"],
-                "html_url": f"https://github.com/{repo_owner}/pkgs/container/{name}",
+                "html_url": f"https://github.com/{repo_owner}/containers/pkgs/container/{name}",
                 "owner": repo_owner
             }
             app_images.append(image)


### PR DESCRIPTION
render-readme.py was creating links that lead to a 404, this should fix the issue. 