### PR TITLE
fix: use `DOTNET_EnableDiagnostics`

### DIFF
--- a/apps/prowlarr/Dockerfile
+++ b/apps/prowlarr/Dockerfile
@@ -9,7 +9,7 @@ ENV UMASK="0002" \
     TZ="Etc/UTC"
 
 ENV \
-    COMPlus_EnableDiagnostics="0" \
+    DOTNET_EnableDiagnostics="0" \
     PROWLARR__UPDATE__BRANCH="${CHANNEL}"
 
 USER root

--- a/apps/radarr/Dockerfile
+++ b/apps/radarr/Dockerfile
@@ -9,7 +9,7 @@ ENV UMASK="0002" \
     TZ="Etc/UTC"
 
 ENV \
-    COMPlus_EnableDiagnostics="0" \
+    DOTNET_EnableDiagnostics="0" \
     RADARR__UPDATE__BRANCH="${CHANNEL}"
 
 USER root

--- a/apps/sonarr/Dockerfile
+++ b/apps/sonarr/Dockerfile
@@ -9,7 +9,7 @@ ENV UMASK="0002" \
     TZ="Etc/UTC"
 
 ENV \
-    COMPlus_EnableDiagnostics="0" \
+    DOTNET_EnableDiagnostics="0" \
     SONARR__UPDATE__BRANCH="${CHANNEL}"
 
 USER root


### PR DESCRIPTION
.net 6 onwards, DOTNET_ is preferred over COMPlus_ https://github.com/dotnet/runtime/commit/fbdcec9060f46353761ac8ee14d11d6206049395 it first uses DOTNET_, and then COMPlus_ as a legacy fallback.

This form is documented here: [dotnet/runtime@1fa1745/docs/workflow/debugging/coreclr/debugging-runtime.md#disabling-managed-attachdebugging](https://github.com/dotnet/runtime/blob/1fa1745581e26069093a679626e346b675aa534f/docs/workflow/debugging/coreclr/debugging-runtime.md#disabling-managed-attachdebugging). COMPlus_ is used as a legacy fallback (naming convention of environment variables should use namespace and COMPlus was some legacy name they stopped using a while back).