### PR TITLE
add htop to sabnzbd container

### DIFF
--- a/apps/sabnzbd/Dockerfile
+++ b/apps/sabnzbd/Dockerfile
@@ -35,6 +35,7 @@ RUN \
         p7zip \
         trurl \
         tzdata \
+        htop \
     && \
     apk add --no-cache --virtual=.build-deps \
         build-base \


### PR DESCRIPTION
It would be useful to have there as sometimes things like direct unpack can take forever with no ability to see if it's just waiting for IO.